### PR TITLE
`laravel/pint` should be a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     "require": {
         "php": "^8.1",
         "statamic/cms": "^4 || ^5 || ^6",
-        "laravel/pint": "^1.13",
         "stillat/statamic-template-resolver": "^1.2",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "ext-libxml": "*"
     },
     "require-dev": {
+        "laravel/pint": "^1.13",
         "pestphp/pest": "^2.24",
         "orchestra/testbench": "^8.14 || ^9",
         "pestphp/pest-plugin-laravel": "^2.2"


### PR DESCRIPTION
This pull request makes `laravel/pint` a dev dependency, as it's not necessary for sites using this package.